### PR TITLE
Version 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Change Log
 
 ## 1.0.0
-
 - Initial release
 
 ## 1.0.1
-
 - Removed debug startup message
 
 ## 1.0.2
-
 - Fix XSS exempt plugin config variable
+
+## 1.0.3
+- Update indentation rules for HTML.
+- The `file` attribute of `{include}` will autocomplete if the current file includes `/templates/` in it’s page.
+- Add `{literal}` tag autocompletion.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The language server provides:
 	- Custom modifiers will be suggested in found in the plugin directory.
 - Variable completion will suggest variables seen elsewhere in the same file.
 - The `file` attribute of `{include}` is a link to the included template.
+- The `file` attribute of `{include}` will autocomplete if the current file includes `/templates/` in it’s page.
 - XSS vulnerability warnings.
 
 ## Extension Settings

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -26,7 +26,7 @@
 		["'", "'"]
 	],
 	"indentationRules": {
-		"increaseIndentPattern": "{(?:capture|foreach|foreachelse|if|elseif|else|php|section|sectionelse|strip)\\b[^}]*}",
-		"decreaseIndentPattern": "{/(?:capture|foreach|if|php|section|strip)\\b[^}]*}"
+		"increaseIndentPattern": "(?:{(?:capture|foreach|foreachelse|if|elseif|else|php|section|sectionelse|strip)\\b[^}]*}|<[^>/]+[^/]>)",
+		"decreaseIndentPattern": "(?:{/(?:capture|foreach|if|php|section|strip)\\b[^}]*}|</[^>]+>)"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	},
 	"displayName": "Smarty Language Server",
 	"description": "Smarty language support",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"engines": {
 		"vscode": "^1.56.0"
 	},

--- a/server/src/smarty/smartyLangData.ts
+++ b/server/src/smarty/smartyLangData.ts
@@ -8,6 +8,7 @@ export const smartyFunctions: string[] = [
 	"include", "include_php",
 	"insert",
 	"ldelim", "rdelim", 
+	"literal",
 	"php",
 	"section", "sectionelse",
 	"strip"


### PR DESCRIPTION
- Update indentation rules for HTML.
- The `file` attribute of `{include}` will autocomplete if the current file includes `/templates/` in it’s page.
- Add `{literal}` tag autocompletion.