### PR TITLE
Don't indent after single line `{if}`

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -26,7 +26,7 @@
 		["'", "'"]
 	],
 	"indentationRules": {
-		"increaseIndentPattern": "(?:{(?:capture|foreach|foreachelse|if|elseif|else|php|section|sectionelse|strip)\\b[^}]*}|(?:<[^>/]+[^/]>[^<]*$))",
+		"increaseIndentPattern": "(?:(?:{(?:capture|foreach|foreachelse|if|elseif|else|php|section|sectionelse|strip)\\b[^}]*}(?:[^{]|[{][^/])*$)|(?:<(?:[^>/]|[{][^{}]+[}])+>[^<]*$))",
 		"decreaseIndentPattern": "(?:^\\s*(?:{/(?:capture|foreach|if|php|section|strip)\\b[^}]*}|</[^>]+>|{foreachelse}|{else}|{elseif ))"
 	}
 }


### PR DESCRIPTION
- `<input {if 1}class="test"{/if} />` should not indent after it.
- With this change, I also needed to be sure that `<div {if a}class="test"{/if}>` would indent.